### PR TITLE
Remove redundant lines from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,6 @@ RUN python3 -m pip install -U pip
 
 WORKDIR /qiskit_alt
 
-# Copy only requirements.txt at this point, so changes to other
-# portions of this repository don't invalidate these image layers.
-# GJL disable these. Probably not necessary
-# COPY requirements.txt .
-# RUN pip install -r requirements.txt
-
-# Not necessary
-# RUN julia -e 'using Pkg; pkg"registry add https://github.com/Qiskit-Extensions/QuantumRegistry.git"'
-
 COPY . .
 RUN pip install -e .
 RUN printf "y\nn\n" | python3 -c "import qiskit_alt; qiskit_alt.project.ensure_init()"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,12 @@ WORKDIR /qiskit_alt
 
 # Copy only requirements.txt at this point, so changes to other
 # portions of this repository don't invalidate these image layers.
-COPY requirements.txt .
-RUN pip install -r requirements.txt
+# GJL disable these. Probably not necessary
+# COPY requirements.txt .
+# RUN pip install -r requirements.txt
 
-RUN julia -e 'using Pkg; pkg"registry add https://github.com/Qiskit-Extensions/QuantumRegistry.git"'
+# Not necessary
+# RUN julia -e 'using Pkg; pkg"registry add https://github.com/Qiskit-Extensions/QuantumRegistry.git"'
 
 COPY . .
 RUN pip install -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = qiskit_alt
-version = 0.1.4
+version = 0.1.5
 description = Julia backend for Qiskit
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -25,7 +25,7 @@ install_requires =
        juliacall
        qiskit-terra ~= 0.19
        qiskit-nature ~= 0.2
-       julia_project >= 0.1.13
+       julia_project >= 0.1.15
 
 
 [options.packages.find]


### PR DESCRIPTION
Installing from requirements.txt is not required. The general registry is installed automatically, and perhaps to a different depot.
