### PR TITLE
Added a dependency "fire"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ package_dir =
 
 
 # ipywidgets is pretty heavy, and only used for version table in notebooks
+# fire is required by the Python Command Line Tool docker_tests/run_dockerfile.py
 install_requires =
        pyscf >= 2.0
        julia
@@ -29,6 +30,7 @@ install_requires =
        qiskit-nature >= 0.2
        julia_project >= 0.1.26
        ipywidgets
+       fire >= 0.4.0
 
 
 [options.packages.find]


### PR DESCRIPTION
The Python Command Line Tool docker_tests/run_dockerfile.py depends on "fire".