### PR TITLE
WIP: Update Dockerfile to fedora36

### DIFF
--- a/docker_tests/Dockerfile
+++ b/docker_tests/Dockerfile
@@ -1,15 +1,9 @@
-# I used fedora:34 rather than fedora:35 as the base image because of
-# https://bugzilla.redhat.com/show_bug.cgi?id=1988199.
-# Comment 26 there points to an upstream RHEL bug, but I am not
-# certain it is the same bug as I was experiencing [garrison].
-FROM fedora:34
+FROM fedora:36
 
 ### Install all needed packages from distribution and remove the package download cache.
-RUN dnf install -y git @development-tools gcc-c++ python3 python3-devel passwd fish emacs wget && \
+### Install and use python 3.9 because pyscf does not work with python 3.10
+RUN dnf install -y git @development-tools gcc-c++ python3.9 python3-devel passwd fish emacs wget && \
       dnf clean dbcache
-
-# Is the followig necessary ?
-RUN python3 -m pip install -U pip
 
 ### Create a user 'quser' and add to sudoers
 
@@ -21,9 +15,9 @@ RUN useradd --create-home --shell /bin/bash quser && echo "quser:quser" | chpass
 WORKDIR /home/quser/qiskit_alt
 USER quser
 
-### Create a virtual envirnoment venv1, install jill.py, and install julia via jill.py
+### Create a virtual environment venv1, install jill.py, and install julia via jill.py
 
-RUN python3 -m venv ./venv1 && source ./venv1/bin/activate && pip install --upgrade pip jill && \
+RUN python3.9 -m venv ./venv1 && source ./venv1/bin/activate && pip install --upgrade pip jill && \
     jill install --confirm
 # Note 'printf "y\n" | jill install' works at the cli, but not here :(
 

--- a/docker_tests/run_dockerfile.sh
+++ b/docker_tests/run_dockerfile.sh
@@ -25,7 +25,7 @@ elif [[ $1 == "rootfish" ]]
 then
     docker run -it qiskit_alt /usr/bin/fish
 else
-    echo Excpecting argument "build" or "run", got $1
+    echo Expecting argument "build" or "run", got $1
     echo "'run_dockerfile.sh build' to build image"
     echo "'run_dockerfile.sh run' to run tests in container"
     echo "'run_dockerfile.sh' to build, then run."


### PR DESCRIPTION
All tests "passed", but there were a few errors along the way.  Not sure how to further evaluate.

```
$ ./run_dockerfile.sh run
docker run -it qiskit_alt:latest  /usr/bin/su -l quser -c "cd qiskit_alt; sh ./run_init_tests.sh"
source ./venv1/bin/activate && python init_test.py
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='pyjulia', depot=False)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='juliacall', depot=False); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='pyjulia', depot=True)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='juliacall', depot=True); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='juliacall', depot=False)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='pyjulia', depot=False); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='juliacall', depot=True)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='pyjulia', depot=True); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=False)'
**** Commands 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=False)' failed with error code Command '['python', '-c', "import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=False)"]' returned non-zero exit status 1.
    Updating registry at `~/.julia/registries/QuantumRegistry`
    Updating git-repo `https://github.com/Qiskit-Extensions/QuantumRegistry`
    Updating registry at `~/.julia/registries/General.toml`
   Resolving package versions...
    Updating `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/Project.toml`
  [6099a3de] + PythonCall v0.9.4
    Updating `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/Manifest.toml`
  [992eb4ea] + CondaPkg v0.2.11
  [0f8b85d8] + JSON3 v1.9.5
  [0b3b1443] + MicroMamba v0.1.8
  [6099a3de] + PythonCall v0.9.4
  [6c6a2e73] + Scratch v1.1.1
  [856f2bd8] + StructTypes v1.8.1
  [e17b2a0c] + UnsafePointers v1.0.0
  Activating project at `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image`
   Resolving package versions...
   Installed RelocatableFolders ─ v0.1.3
   Installed JLD2 ─────────────── v0.4.22
   Installed InlineTest ───────── v0.2.0
   Installed ReTest ───────────── v0.3.2
   Installed Aqua ─────────────── v0.5.5
   Installed TranscodingStreams ─ v0.9.6
   Installed PackageCompiler ──── v2.0.7
   Installed Reexport ─────────── v1.2.2
   Installed FileIO ───────────── v1.15.0
    Updating `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/Project.toml`
  [4c88cf16] + Aqua v0.5.5
  [f7ec468b] + ElectronicStructure v0.1.8
  [28f27b66] + IsApprox v0.1.4
  [033835bb] + JLD2 v0.4.22
  [9b87118b] + PackageCompiler v2.0.7
  [438e738f] + PyCall v1.93.1
  [8d55b643] + QiskitQuantumInfo v0.1.0
  [d0cc4389] + QuantumOps v0.1.5
  [e0db7c4e] + ReTest v0.3.2
  [295af30f] + Revise v3.4.0
  [7d983096] + SparseArraysN v0.0.3
  [90137ffa] + StaticArrays v1.5.2
    Updating `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/Manifest.toml`
  [79e6a3ab] + Adapt v3.4.0
  [4c88cf16] + Aqua v0.5.5
  [dce04be8] + ArgCheck v2.3.0
  [ec485272] + ArnoldiMethod v0.1.0
  [198e06fe] + BangBang v0.3.36
  [9718e550] + Baselet v0.1.1
  [d360d2e6] + ChainRulesCore v1.15.3
  [9e997f8a] + ChangesOfVariables v0.1.4
  [da1fd8a2] + CodeTracking v1.1.0
  [34da2185] + Compat v3.45.0
  [a33af91c] + CompositionsBase v0.1.1
  [8f4d0f93] + Conda v1.7.0
  [187b0558] + ConstructionBase v1.4.0
  [9a962f9c] + DataAPI v1.10.0
  [864edb3b] + DataStructures v0.18.13
  [e2d170a0] + DataValueInterfaces v1.0.0
  [244e2a9f] + DefineSingletons v0.1.2
  [b552c78f] + DiffRules v1.11.0
  [ffbed154] + DocStringExtensions v0.9.1
  [f7ec468b] + ElectronicStructure v0.1.8
  [5789e2e9] + FileIO v1.15.0
  [2cd5bd5f] + ILog2 v0.2.4
  [d25df0c9] + Inflate v0.1.2
  [22cec73e] + InitialValues v0.3.1
  [bd334432] + InlineTest v0.2.0
  [3587e190] + InverseFunctions v0.1.7
  [92d709cd] + IrrationalConstants v0.1.1
  [28f27b66] + IsApprox v0.1.4
  [82899510] + IteratorInterfaceExtensions v1.0.0
  [033835bb] + JLD2 v0.4.22
  [692b3bcd] + JLLWrappers v1.4.1
  [682c06a0] + JSON v0.21.3
  [aa1ae85d] + JuliaInterpreter v0.9.15
  [093fc24a] + LightGraphs v1.3.5
  [2ab3a3ac] + LogExpFunctions v0.3.17
  [6f1432cf] + LoweredCodeUtils v2.2.2
  [1914dd2f] + MacroTools v0.5.9
  [128add7d] + MicroCollections v0.1.2
  [77ba4419] + NaNMath v1.0.1
  [bac558e1] + OrderedCollections v1.4.1
  [9b87118b] + PackageCompiler v2.0.7
  [69de0a69] + Parsers v2.3.2
  [7b2266bf] + PeriodicTable v1.1.2
  [21216c6a] + Preferences v1.3.0
  [438e738f] + PyCall v1.93.1
  [8d55b643] + QiskitQuantumInfo v0.1.0
  [d0cc4389] + QuantumOps v0.1.5
  [e0db7c4e] + ReTest v0.3.2
  [189a3867] + Reexport v1.2.2
  [42d2dcc6] + Referenceables v0.1.2
  [05181044] + RelocatableFolders v0.1.3
  [ae029012] + Requires v1.3.0
  [295af30f] + Revise v3.4.0
  [6c6a2e73] + Scratch v1.1.1
  [efcf1570] + Setfield v0.8.2
  [699a6c99] + SimpleTraits v0.9.4
  [7d983096] + SparseArraysN v0.0.3
  [276daf66] + SpecialFunctions v2.1.7
  [171d559e] + SplittablesBase v0.1.14
  [90137ffa] + StaticArrays v1.5.2
  [1e83bf80] + StaticArraysCore v1.0.1
  [3783bdb8] + TableTraits v1.0.1
  [bd369af6] + Tables v1.7.0
  [ac1d9e8a] + ThreadsX v0.1.10
  [3bb67fe8] + TranscodingStreams v0.9.6
  [28d57a85] + Transducers v0.4.73
  [bc48ee85] + Tullio v0.3.4
  [1986cc42] + Unitful v1.11.0
  [81def892] + VersionParsing v1.3.0
  [8603256b] + ZChop v0.3.10
  [700de1a5] + ZygoteRules v0.2.2
  [efe28fd5] + OpenSpecFun_jll v0.5.5+0
  [0dad84c5] + ArgTools
  [56f22d72] + Artifacts
  [2a0f44e3] + Base64
  [ade2ca70] + Dates
  [8bb1440f] + DelimitedFiles
  [8ba89e20] + Distributed
  [f43a241f] + Downloads
  [7b1f6079] + FileWatching
  [9fa8497b] + Future
  [b77e0a4c] + InteractiveUtils
  [4af54fe1] + LazyArtifacts
  [b27032c2] + LibCURL
  [76f85450] + LibGit2
  [8f399da3] + Libdl
  [37e2e46d] + LinearAlgebra
  [56ddb016] + Logging
  [d6f4376e] + Markdown
  [a63ad114] + Mmap
  [ca575930] + NetworkOptions
  [44cfe95a] + Pkg
  [de0858da] + Printf
  [3fa0cd96] + REPL
  [9a3f8284] + Random
  [ea8e919c] + SHA
  [9e88b42a] + Serialization
  [1a1011a3] + SharedArrays
  [6462fe0b] + Sockets
  [2f01184e] + SparseArrays
  [10745b16] + Statistics
  [fa267f1f] + TOML
  [a4e569a6] + Tar
  [8dfed614] + Test
  [cf7118a7] + UUIDs
  [4ec0a83e] + Unicode
  [e66e0078] + CompilerSupportLibraries_jll
  [deac9b47] + LibCURL_jll
  [29816b5a] + LibSSH2_jll
  [c8ffd9c3] + MbedTLS_jll
  [14a3606d] + MozillaCACerts_jll
  [4536629a] + OpenBLAS_jll
  [05823500] + OpenLibm_jll
  [83775a58] + Zlib_jll
  [8e850b90] + libblastrampoline_jll
  [8e850ede] + nghttp2_jll
  [3f19e933] + p7zip_jll
Precompiling project...
  ✗ InlineTest
  ✗ Reexport
  ✗ TranscodingStreams
  ✗ FileIO
  ✗ Aqua
  ✗ RelocatableFolders
  ✗ ReTest
  ✗ JLD2
  ✗ PackageCompiler
  0 dependencies successfully precompiled in 1 seconds (70 already precompiled)
  9 dependencies errored. To see a full report either run `import Pkg; Pkg.precompile()` or load the packages
   Resolving package versions...
    Updating `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/Project.toml`
  [6099a3de] + PythonCall v0.9.4
    Updating `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/Manifest.toml`
  [992eb4ea] + CondaPkg v0.2.11
  [0f8b85d8] + JSON3 v1.9.5
  [0b3b1443] + MicroMamba v0.1.8
  [6099a3de] + PythonCall v0.9.4
  [856f2bd8] + StructTypes v1.8.1
  [e17b2a0c] + UnsafePointers v1.0.0
  No Changes to `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/Project.toml`
  No Changes to `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/Manifest.toml`
ERROR: could not load library "/home/quser/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/../lib/julia/sys.so"
/home/quser/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/../lib/julia/sys.so: cannot open shared object file: No such file or directory
  Activating project at `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3`
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/_julia_project.py", line 278, in ensure_init
    self.init()
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/_julia_project.py", line 433, in init
    self.compile()
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/_julia_project.py", line 586, in compile
    self.julia_system_image.compile()
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/julia_system_image.py", line 69, in compile
    self._compile()
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/julia_system_image.py", line 201, in _compile
    self.calljulia.seval_all(cscript)
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/pyjulia.py", line 51, in seval_all
    return julia.Main.eval(_str.strip())
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 621, in eval
    ans = self._call(src)
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 549, in _call
    self.check_exception(src)
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 603, in check_exception
    raise JuliaError(u'Exception \'{}\' occurred while calling julia code:\n{}'
julia.core.JuliaError: Exception 'Failed to precompile PackageCompiler [9b87118b-4619-50d2-8e1e-99f35a4d4d9d] to /home/quser/.julia/compiled/v1.7/PackageCompiler/jl_jEYL1d.' occurred while calling julia code:
import PackageCompiler
        using Libdl: Libdl
        let
          ENV["PYCALL_JL_RUNTIME_PYTHON"] = Sys.which("python")
          ENV["PYTHON"] = Sys.which("python")
          packages = include("packages.jl")
          if true
             push!(packages, :PyCall)
          end
          if true
             push!(packages, :PythonCall)
          end
          sysimage_path = joinpath(@__DIR__, "sys_julia_project." * Libdl.dlext)

          if isfile("compile_exercise_script.jl")
            PackageCompiler.create_sysimage(packages; sysimage_path=sysimage_path,
                precompile_execution_file=joinpath(@__DIR__, "compile_exercise_script.jl"),
                incremental=true,
                project=joinpath(@__DIR__, "."))
          else
            PackageCompiler.create_sysimage(packages; sysimage_path=sysimage_path,
                incremental=true,
                project=joinpath(@__DIR__, "."))
          end
        end

running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='juliacall', depot=False); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=True)'
**** Commands 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=True)' failed with error code Command '['python', '-c', "import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=True)"]' returned non-zero exit status 1.
    Updating registry at `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/depot/registries/QuantumRegistry`
    Updating git-repo `https://github.com/Qiskit-Extensions/QuantumRegistry`
    Updating registry at `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/depot/registries/General.toml`
   Resolving package versions...
   Installed MicroMamba ───── v0.1.8
   Installed UnsafePointers ─ v1.0.0
   Installed CondaPkg ─────── v0.2.11
   Installed StructTypes ──── v1.8.1
   Installed JSON3 ────────── v1.9.5
   Installed Scratch ──────── v1.1.1
   Installed PythonCall ───── v0.9.4
    Updating `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/Project.toml`
  [6099a3de] + PythonCall v0.9.4
    Updating `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/Manifest.toml`
  [992eb4ea] + CondaPkg v0.2.11
  [0f8b85d8] + JSON3 v1.9.5
  [0b3b1443] + MicroMamba v0.1.8
  [6099a3de] + PythonCall v0.9.4
  [6c6a2e73] + Scratch v1.1.1
  [856f2bd8] + StructTypes v1.8.1
  [e17b2a0c] + UnsafePointers v1.0.0
Precompiling project...
  ✓ Scratch
  ✓ UnsafePointers
  ✓ MicroMamba
  ✓ StructTypes
  ✓ JSON3
  ✓ CondaPkg
  ✓ PythonCall
  7 dependencies successfully precompiled in 21 seconds (69 already precompiled)
  Activating project at `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image`
   Resolving package versions...
   Installed InlineTest ───────── v0.2.0
   Installed RelocatableFolders ─ v0.1.3
   Installed Aqua ─────────────── v0.5.5
   Installed TranscodingStreams ─ v0.9.6
   Installed Reexport ─────────── v1.2.2
   Installed ReTest ───────────── v0.3.2
   Installed JLD2 ─────────────── v0.4.22
   Installed PackageCompiler ──── v2.0.7
   Installed FileIO ───────────── v1.15.0
    Updating `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/Project.toml`
  [4c88cf16] + Aqua v0.5.5
  [f7ec468b] + ElectronicStructure v0.1.8
  [28f27b66] + IsApprox v0.1.4
  [033835bb] + JLD2 v0.4.22
  [9b87118b] + PackageCompiler v2.0.7
  [438e738f] + PyCall v1.93.1
  [8d55b643] + QiskitQuantumInfo v0.1.0
  [d0cc4389] + QuantumOps v0.1.5
  [e0db7c4e] + ReTest v0.3.2
  [295af30f] + Revise v3.4.0
  [7d983096] + SparseArraysN v0.0.3
  [90137ffa] + StaticArrays v1.5.2
    Updating `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/Manifest.toml`
  [79e6a3ab] + Adapt v3.4.0
  [4c88cf16] + Aqua v0.5.5
  [dce04be8] + ArgCheck v2.3.0
  [ec485272] + ArnoldiMethod v0.1.0
  [198e06fe] + BangBang v0.3.36
  [9718e550] + Baselet v0.1.1
  [d360d2e6] + ChainRulesCore v1.15.3
  [9e997f8a] + ChangesOfVariables v0.1.4
  [da1fd8a2] + CodeTracking v1.1.0
  [34da2185] + Compat v3.45.0
  [a33af91c] + CompositionsBase v0.1.1
  [8f4d0f93] + Conda v1.7.0
  [187b0558] + ConstructionBase v1.4.0
  [9a962f9c] + DataAPI v1.10.0
  [864edb3b] + DataStructures v0.18.13
  [e2d170a0] + DataValueInterfaces v1.0.0
  [244e2a9f] + DefineSingletons v0.1.2
  [b552c78f] + DiffRules v1.11.0
  [ffbed154] + DocStringExtensions v0.9.1
  [f7ec468b] + ElectronicStructure v0.1.8
  [5789e2e9] + FileIO v1.15.0
  [2cd5bd5f] + ILog2 v0.2.4
  [d25df0c9] + Inflate v0.1.2
  [22cec73e] + InitialValues v0.3.1
  [bd334432] + InlineTest v0.2.0
  [3587e190] + InverseFunctions v0.1.7
  [92d709cd] + IrrationalConstants v0.1.1
  [28f27b66] + IsApprox v0.1.4
  [82899510] + IteratorInterfaceExtensions v1.0.0
  [033835bb] + JLD2 v0.4.22
  [692b3bcd] + JLLWrappers v1.4.1
  [682c06a0] + JSON v0.21.3
  [aa1ae85d] + JuliaInterpreter v0.9.15
  [093fc24a] + LightGraphs v1.3.5
  [2ab3a3ac] + LogExpFunctions v0.3.17
  [6f1432cf] + LoweredCodeUtils v2.2.2
  [1914dd2f] + MacroTools v0.5.9
  [128add7d] + MicroCollections v0.1.2
  [77ba4419] + NaNMath v1.0.1
  [bac558e1] + OrderedCollections v1.4.1
  [9b87118b] + PackageCompiler v2.0.7
  [69de0a69] + Parsers v2.3.2
  [7b2266bf] + PeriodicTable v1.1.2
  [21216c6a] + Preferences v1.3.0
  [438e738f] + PyCall v1.93.1
  [8d55b643] + QiskitQuantumInfo v0.1.0
  [d0cc4389] + QuantumOps v0.1.5
  [e0db7c4e] + ReTest v0.3.2
  [189a3867] + Reexport v1.2.2
  [42d2dcc6] + Referenceables v0.1.2
  [05181044] + RelocatableFolders v0.1.3
  [ae029012] + Requires v1.3.0
  [295af30f] + Revise v3.4.0
  [6c6a2e73] + Scratch v1.1.1
  [efcf1570] + Setfield v0.8.2
  [699a6c99] + SimpleTraits v0.9.4
  [7d983096] + SparseArraysN v0.0.3
  [276daf66] + SpecialFunctions v2.1.7
  [171d559e] + SplittablesBase v0.1.14
  [90137ffa] + StaticArrays v1.5.2
  [1e83bf80] + StaticArraysCore v1.0.1
  [3783bdb8] + TableTraits v1.0.1
  [bd369af6] + Tables v1.7.0
  [ac1d9e8a] + ThreadsX v0.1.10
  [3bb67fe8] + TranscodingStreams v0.9.6
  [28d57a85] + Transducers v0.4.73
  [bc48ee85] + Tullio v0.3.4
  [1986cc42] + Unitful v1.11.0
  [81def892] + VersionParsing v1.3.0
  [8603256b] + ZChop v0.3.10
  [700de1a5] + ZygoteRules v0.2.2
  [efe28fd5] + OpenSpecFun_jll v0.5.5+0
  [0dad84c5] + ArgTools
  [56f22d72] + Artifacts
  [2a0f44e3] + Base64
  [ade2ca70] + Dates
  [8bb1440f] + DelimitedFiles
  [8ba89e20] + Distributed
  [f43a241f] + Downloads
  [7b1f6079] + FileWatching
  [9fa8497b] + Future
  [b77e0a4c] + InteractiveUtils
  [4af54fe1] + LazyArtifacts
  [b27032c2] + LibCURL
  [76f85450] + LibGit2
  [8f399da3] + Libdl
  [37e2e46d] + LinearAlgebra
  [56ddb016] + Logging
  [d6f4376e] + Markdown
  [a63ad114] + Mmap
  [ca575930] + NetworkOptions
  [44cfe95a] + Pkg
  [de0858da] + Printf
  [3fa0cd96] + REPL
  [9a3f8284] + Random
  [ea8e919c] + SHA
  [9e88b42a] + Serialization
  [1a1011a3] + SharedArrays
  [6462fe0b] + Sockets
  [2f01184e] + SparseArrays
  [10745b16] + Statistics
  [fa267f1f] + TOML
  [a4e569a6] + Tar
  [8dfed614] + Test
  [cf7118a7] + UUIDs
  [4ec0a83e] + Unicode
  [e66e0078] + CompilerSupportLibraries_jll
  [deac9b47] + LibCURL_jll
  [29816b5a] + LibSSH2_jll
  [c8ffd9c3] + MbedTLS_jll
  [14a3606d] + MozillaCACerts_jll
  [4536629a] + OpenBLAS_jll
  [05823500] + OpenLibm_jll
  [83775a58] + Zlib_jll
  [8e850b90] + libblastrampoline_jll
  [8e850ede] + nghttp2_jll
  [3f19e933] + p7zip_jll
Precompiling project...
  ✗ FileIO
  ✗ InlineTest
  ✗ Reexport
  ✗ TranscodingStreams
  ✗ Aqua
  ✗ JLD2
  ✗ RelocatableFolders
  ✗ ReTest
  ✗ PackageCompiler
  0 dependencies successfully precompiled in 0 seconds (70 already precompiled)
  9 dependencies errored. To see a full report either run `import Pkg; Pkg.precompile()` or load the packages
   Resolving package versions...
    Updating `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/Project.toml`
  [6099a3de] + PythonCall v0.9.4
    Updating `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/Manifest.toml`
  [992eb4ea] + CondaPkg v0.2.11
  [0f8b85d8] + JSON3 v1.9.5
  [0b3b1443] + MicroMamba v0.1.8
  [6099a3de] + PythonCall v0.9.4
  [856f2bd8] + StructTypes v1.8.1
  [e17b2a0c] + UnsafePointers v1.0.0
  No Changes to `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/Project.toml`
  No Changes to `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/Manifest.toml`
ERROR: could not load library "/home/quser/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/../lib/julia/sys.so"
/home/quser/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/sys_image/../lib/julia/sys.so: cannot open shared object file: No such file or directory
  Activating project at `~/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3`
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/_julia_project.py", line 278, in ensure_init
    self.init()
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/_julia_project.py", line 433, in init
    self.compile()
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/_julia_project.py", line 586, in compile
    self.julia_system_image.compile()
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/julia_system_image.py", line 69, in compile
    self._compile()
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/julia_system_image.py", line 201, in _compile
    self.calljulia.seval_all(cscript)
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/pyjulia.py", line 51, in seval_all
    return julia.Main.eval(_str.strip())
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 621, in eval
    ans = self._call(src)
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 549, in _call
    self.check_exception(src)
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 603, in check_exception
    raise JuliaError(u'Exception \'{}\' occurred while calling julia code:\n{}'
julia.core.JuliaError: Exception 'Failed to precompile PackageCompiler [9b87118b-4619-50d2-8e1e-99f35a4d4d9d] to /home/quser/qiskit_alt/venv1/julia_project/qiskit_alt-1.7.3/depot/compiled/v1.7/PackageCompiler/jl_lmLgdt.' occurred while calling julia code:
import PackageCompiler
        using Libdl: Libdl
        let
          ENV["PYCALL_JL_RUNTIME_PYTHON"] = Sys.which("python")
          ENV["PYTHON"] = Sys.which("python")
          packages = include("packages.jl")
          if true
             push!(packages, :PyCall)
          end
          if true
             push!(packages, :PythonCall)
          end
          sysimage_path = joinpath(@__DIR__, "sys_julia_project." * Libdl.dlext)

          if isfile("compile_exercise_script.jl")
            PackageCompiler.create_sysimage(packages; sysimage_path=sysimage_path,
                precompile_execution_file=joinpath(@__DIR__, "compile_exercise_script.jl"),
                incremental=true,
                project=joinpath(@__DIR__, "."))
          else
            PackageCompiler.create_sysimage(packages; sysimage_path=sysimage_path,
                incremental=true,
                project=joinpath(@__DIR__, "."))
          end
        end

running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='juliacall', depot=True); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='juliacall', depot=False)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=False); qiskit_alt.project.clean_all()'
**** Commands 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=False); qiskit_alt.project.clean_all()' failed with error code Command '['python', '-c', "import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=False); qiskit_alt.project.clean_all()"]' returned non-zero exit status 1.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/_julia_project.py", line 278, in ensure_init
    self.init()
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/_julia_project.py", line 418, in init
    self.calljulia.start_julia()
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/pyjulia.py", line 132, in start_julia
    raise err
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/pyjulia.py", line 126, in start_julia
    import julia.Base
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 664, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 627, in _load_backward_compatible
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 248, in load_module
    elif self.julia.isafunction(juliapath):
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 239, in julia
    self.__class__.julia = julia = Julia()
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 513, in __init__
    self._call("const PyCall = Base.require({0})".format(PYCALL_PKGID))
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 549, in _call
    self.check_exception(src)
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 603, in check_exception
    raise JuliaError(u'Exception \'{}\' occurred while calling julia code:\n{}'
julia.core.JuliaError: Exception 'ArgumentError' occurred while calling julia code:
const PyCall = Base.require(Base.PkgId(Base.UUID("438e738f-606a-5dbb-bf0a-cddfbfd45ab0"), "PyCall"))

running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='juliacall', depot=True)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=True); qiskit_alt.project.clean_all()'
**** Commands 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=True); qiskit_alt.project.clean_all()' failed with error code Command '['python', '-c', "import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=True); qiskit_alt.project.clean_all()"]' returned non-zero exit status 1.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/_julia_project.py", line 278, in ensure_init
    self.init()
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/_julia_project.py", line 418, in init
    self.calljulia.start_julia()
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/pyjulia.py", line 132, in start_julia
    raise err
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia_project/pyjulia.py", line 126, in start_julia
    import julia.Base
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 664, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 627, in _load_backward_compatible
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 248, in load_module
    elif self.julia.isafunction(juliapath):
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 239, in julia
    self.__class__.julia = julia = Julia()
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 513, in __init__
    self._call("const PyCall = Base.require({0})".format(PYCALL_PKGID))
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 549, in _call
    self.check_exception(src)
  File "/home/quser/qiskit_alt/venv1/lib64/python3.9/site-packages/julia/core.py", line 603, in check_exception
    raise JuliaError(u'Exception \'{}\' occurred while calling julia code:\n{}'
julia.core.JuliaError: Exception 'ArgumentError' occurred while calling julia code:
const PyCall = Base.require(Base.PkgId(Base.UUID("438e738f-606a-5dbb-bf0a-cddfbfd45ab0"), "PyCall"))

**** 12 of 16 installation tests passed

source ./venv_static/bin/activate && python init_test.py
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='pyjulia', depot=False)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='juliacall', depot=False); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='pyjulia', depot=True)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='juliacall', depot=True); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='juliacall', depot=False)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='pyjulia', depot=False); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='juliacall', depot=True)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='pyjulia', depot=True); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=False)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='juliacall', depot=False); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=True)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='juliacall', depot=True); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='juliacall', depot=False)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=False); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='juliacall', depot=True)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=True); qiskit_alt.project.clean_all()'
16 of 16 installation tests passed

conda activate qiskit_alt_env && python init_test.py
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='pyjulia', depot=False)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='juliacall', depot=False); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='pyjulia', depot=True)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='juliacall', depot=True); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='juliacall', depot=False)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='pyjulia', depot=False); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='juliacall', depot=True)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=False, calljulia='pyjulia', depot=True); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=False)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='juliacall', depot=False); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=True)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='juliacall', depot=True); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='juliacall', depot=False)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=False); qiskit_alt.project.clean_all()'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='juliacall', depot=True)'
running 'import qiskit_alt; qiskit_alt.project.ensure_init(compile=True, calljulia='pyjulia', depot=True); qiskit_alt.project.clean_all()'
16 of 16 installation tests passed
```